### PR TITLE
Отделение css от js в сборке для прода

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,6 +2,8 @@
 import fs from 'fs';
 import path from 'path';
 import webpack from 'webpack';
+import ExtractTextPlugin from 'extract-text-webpack-plugin';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 webpack({
   debug: false,
@@ -24,10 +26,13 @@ webpack({
       ],
     }, {
       test: /\.scss$/,
-      loader: 'style!' +
-              'css!' +
-              'autoprefixer?{browsers: ["last 2 version", "IE 9"]}!' +
-              'sass?outputStyle=compressed',
+      loader: ExtractTextPlugin.extract(
+        'style-loader',
+        'css-loader!autoprefixer-loader?{browsers: ["last 2 version", "IE 9"]}!' +
+        'sass-loader?outputStyle=compressed'),
+      include: [
+        path.join(__dirname, 'client'),
+      ],
     }],
   },
   resolve: {
@@ -41,6 +46,13 @@ webpack({
     extensions: ['', '.js', '.jsx', '.json', '.scss', '.css'],
   },
   plugins: [
+    new ExtractTextPlugin('bundle.css', { allChunks: true }),
+    new HtmlWebpackPlugin({
+      inject: 'body',
+      hash: true,
+      filename: 'index.html',
+      template: __dirname + '/client/index.html',
+    }),
     new webpack.optimize.UglifyJsPlugin({
       compress: {
         warnings: false,

--- a/client/index.html
+++ b/client/index.html
@@ -7,6 +7,5 @@
 </head>
 <body>
   <div id="content" class="b-container"></div>
-  <script src="bundle.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "3.3.2",
     "extract-text-webpack-plugin": "0.8.2",
+    "html-webpack-plugin": "^1.6.1",
     "mocha": "2.3.2",
     "node-sass": "3.3.3",
     "pre-commit": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "3.3.2",
     "extract-text-webpack-plugin": "0.8.2",
-    "html-webpack-plugin": "^1.6.1",
+    "html-webpack-plugin": "1.6.1",
     "mocha": "2.3.2",
     "node-sass": "3.3.3",
     "pre-commit": "1.1.1",

--- a/server/server.dev.js
+++ b/server/server.dev.js
@@ -13,7 +13,6 @@ import webpack from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
 import dev from '../webpack.config.babel';
 
-const FILEHOST = 'localhost';
 const FILEPORT = 8080;
 const FILEPATH = '/../static';
 
@@ -25,8 +24,8 @@ const fileServer = new WebpackDevServer(webpack(dev), {
 });
 
 fileServer.use('/', express.static(__dirname + FILEPATH));
-fileServer.listen(FILEPORT, FILEHOST, () => {
-  console.log('FIle and hot reload server listening on ' + FILEHOST + ':' + FILEPORT);
+fileServer.listen(FILEPORT, () => {
+  console.log('FIle and hot reload server listening on *:' + FILEPORT);
 });
 
 // --- MOCK FILE SERVER
@@ -34,11 +33,10 @@ fileServer.listen(FILEPORT, FILEHOST, () => {
 const app = express();
 const mockServer = new http.Server(app);
 
-const MOCKHOST = 'localhost';
 const MOCKPORT = 3000;
 
 app.use('/', express.static(__dirname + '/mock'));
 mockServer.listen(MOCKPORT, () => {
-  console.log('Mock server listening on ' + MOCKHOST + ':' + MOCKPORT);
+  console.log('Mock server listening on *:' + MOCKPORT);
 });
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 const FILEHOST = 'localhost';
 const FILEPORT = 8080;
@@ -45,6 +46,11 @@ export default {
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
+    new HtmlWebpackPlugin({
+      inject: 'body',
+      filename: 'index.html',
+      template: __dirname + '/client/index.html',
+    }),
     new webpack.DefinePlugin({
       NODE_ENV: '"development"',
       DATAPORT: '"3001"',


### PR DESCRIPTION
Теперь в сборке для прода css отдельно от js.
Поскольку теперь приходиться препроцессить `index.html` то перенес его в папку `client`
