### PR TITLE
Webpack less verbose

### DIFF
--- a/server/server.dev.js
+++ b/server/server.dev.js
@@ -19,7 +19,10 @@ const fileServer = new WebpackDevServer(webpack(dev), {
   publicPath: dev.output.publicPath,
   hot: true,
   historyApiFallback: true,
-  stats: {colors: true},
+  stats: {
+    colors: true,
+    chunkModules: false,
+  },
 });
 
 fileServer.use('/', express.static(__dirname + FILEPATH));


### PR DESCRIPTION
Но при этом в отличие от #154 показывает после сборки:

```
Version: webpack 1.12.2
Time: 6103ms
chunk    {0} bundle.js (main) 1.78 MB [rendered]
webpack: bundle is now VALID.
```
